### PR TITLE
add new options and improve code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "xsession_manager/tests/run_main.py",
             "console": "integratedTerminal",
-            "args": ["-r","-i", "firefox"],
+            "args": ["-r","-i", "pycharm", "-vv"],
             "justMyCode": false
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "xsession_manager/tests/run_main.py",
             "console": "integratedTerminal",
-            "args": ["-r","-i", "pycharm", "-vv"],
+            "args": ["-r","testing-save-session","-i", "spotify"],
             "justMyCode": false
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: run_main",
+            "type": "python",
+            "request": "launch",
+            "program": "xsession_manager/tests/run_main.py",
+            "console": "integratedTerminal",
+            "args": ["-r","-i", "firefox"],
+            "justMyCode": false
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "xsession_manager/tests/run_main.py",
             "console": "integratedTerminal",
-            "args": ["-r","testing-save-session","-i", "spotify"],
+            "args": ["-r","testing-save-session","-i", "super"],
             "justMyCode": false
         }
     ]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author='nlpsuge',
 
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
         'Programming Language :: Python :: 3.6',

--- a/xsession_manager/arguments_handler.py
+++ b/xsession_manager/arguments_handler.py
@@ -157,7 +157,7 @@ class ArgumentsHandler():
                 xsm = XSessionManager(verbose=self.args.verbose, vv=self.args.vv)
                 xsm.restore_session(pop_up_a_dialog_to_restore, restoring_interval)
 
-        # Sort sessions based on motification time in ascending order
+        # Sort sessions based on modification time in ascending order
         if list_sessions:
             print()
             session_files = filter(lambda x: os.path.isfile(os.path.join(constants.Locations.BASE_LOCATION_OF_SESSIONS, x)), 

--- a/xsession_manager/arguments_handler.py
+++ b/xsession_manager/arguments_handler.py
@@ -16,200 +16,221 @@ from .utils import string_utils, wmctl_wrapper
 from .xsession_manager import XSessionManager
 
 
-def check_and_reset_args(args: Namespace):
-    save = args.save
-    restore = args.restore
-    list_sessions = args.list
-    detail = args.detail
-    close_all = args.close_all
-    pop_up_a_dialog_to_restore = args.pr
-    move_automatically = args.move_automatically
+class ArgumentsHandler():
+    
+    def __init__(self, args: Namespace) -> None:
+        self.args = args
+        if self.args.vv:
+            self.args.verbose = True
+            
+    def check_and_preset_args(self):
+        save = self.args.save
+        restore = self.args.restore
+        list_sessions = self.args.list
+        detail = self.args.detail
+        close_all = self.args.close_all
+        pop_up_a_dialog_to_restore = self.args.pr
+        move_automatically = self.args.move_automatically
+        
+        verbose = self.args.verbose
+        vv = self.args.vv
 
-    # Need to deal with this kind of case when user type -s' '
-    argv = [a.strip() for a in sys.argv[1:]]
-    # print('Arguments input by user: ' + str(argv))
-    if string_utils.empty_string(save) \
-            and ('-s' in argv or '--save' in argv):
-        args.save = Locations.DEFAULT_SESSION_NAME
-        save = args.save
-    if string_utils.empty_string(restore) \
-            and ('-r' in argv or '--restore' in argv):
-        args.restore = Locations.DEFAULT_SESSION_NAME
-        restore = args.restore
-    if string_utils.empty_string(pop_up_a_dialog_to_restore) \
-            and ('-pr' in argv):
-        args.pr = Locations.DEFAULT_SESSION_NAME
-        pop_up_a_dialog_to_restore = args.pr
-    if string_utils.empty_string(detail) \
-            and ('-t' in argv or '--detail' in argv):
-        args.detail = Locations.DEFAULT_SESSION_NAME
-        detail = args.detail
-    if string_utils.empty_string(move_automatically) \
-            and ('-ma' in argv or '--move-automatically' in argv):
-        args.move_automatically = Locations.DEFAULT_SESSION_NAME
-        move_automatically = args.move_automatically
+        if verbose:
+            print('Namespace object before handling by this program: ' + str(self.args))
 
-    # -im/--including-apps-with-multiple-windows can only be used along with -c/--close-all
-    if ('-im' in argv or '--including-apps-with-multiple-windows' in argv) and not ('-c' in argv or '--close-all' in argv):
-        raise argparse.ArgumentTypeError('argument -im/--including-apps-with-multiple-windows : '
-                                         'only allowed with -c/--close-all')
+        # Need to deal with this kind of case when user type -s' '
+        argv = [a.strip() for a in sys.argv[1:]]
+        if verbose:
+            print('Arguments input by user: ' + str(argv))
+            
+        if string_utils.empty_string(save) \
+                and ('-s' in argv or '--save' in argv):
+            self.args.save = Locations.DEFAULT_SESSION_NAME
+            save = self.args.save
+        if string_utils.empty_string(restore) \
+                and ('-r' in argv or '--restore' in argv):
+            self.args.restore = Locations.DEFAULT_SESSION_NAME
+            restore = self.args.restore
+        if string_utils.empty_string(pop_up_a_dialog_to_restore) \
+                and ('-pr' in argv):
+            self.args.pr = Locations.DEFAULT_SESSION_NAME
+            pop_up_a_dialog_to_restore = self.args.pr
+        if string_utils.empty_string(detail) \
+                and ('-t' in argv or '--detail' in argv):
+            self.args.detail = Locations.DEFAULT_SESSION_NAME
+            detail = self.args.detail
+        if string_utils.empty_string(move_automatically) \
+                and ('-ma' in argv or '--move-automatically' in argv):
+            self.args.move_automatically = Locations.DEFAULT_SESSION_NAME
+            move_automatically = self.args.move_automatically
 
-    # print('Namespace object after handling by this program: ' + str(args))
+        # -im/--including-apps-with-multiple-windows can only be used along with -c/--close-all
+        if ('-im' in argv or '--including-apps-with-multiple-windows' in argv) and not ('-c' in argv or '--close-all' in argv):
+            raise argparse.ArgumentTypeError('argument -im/--including-apps-with-multiple-windows : '
+                                            'only allowed with -c/--close-all')
 
-    if save or restore or close_all:
-        if list_sessions:
-            raise argparse.ArgumentTypeError('argument -l/--list : '
-                                             'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
-        if detail:
-            raise argparse.ArgumentTypeError('argument -t/--detail : '
-                                             'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
-        if pop_up_a_dialog_to_restore:
-            raise argparse.ArgumentTypeError('argument -pr : '
-                                             'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
-        if move_automatically:
-            raise argparse.ArgumentTypeError('argument -ma/--move-automatically : '
-                                             'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
+        if verbose:
+            print('Namespace object after handling by this program: ' + str(self.args))
 
-    if close_all is None \
-            and not string_utils.empty_string(restore):
-        # get the opening windows via wmctl
-        print("Opening windows list:")
-        running_windows = wmctl_wrapper.get_running_windows_raw()
-        if len(running_windows) > 0:
-            for rw in running_windows:
-                print(rw)
-            print('Opening windows were found! Do you want to continue to restore a session?')
-            wait_for_answer()
+        if save or restore or close_all:
+            if list_sessions:
+                raise argparse.ArgumentTypeError('argument -l/--list : '
+                                                'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
+            if detail:
+                raise argparse.ArgumentTypeError('argument -t/--detail : '
+                                                'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
+            if pop_up_a_dialog_to_restore:
+                raise argparse.ArgumentTypeError('argument -pr : '
+                                                'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
+            if move_automatically:
+                raise argparse.ArgumentTypeError('argument -ma/--move-automatically : '
+                                                'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
+
+        if close_all is None \
+                and not string_utils.empty_string(restore):
+            # get the opening windows via wmctl
+            if vv:
+                print("Opening windows list:")
+                running_windows = wmctl_wrapper.get_running_windows_raw()
+                if len(running_windows) > 0:
+                    for rw in running_windows:
+                        print(rw)
+                    
+            print('Do you want to continue to restore a session?')
+            self.wait_for_answer()
             print("Let's rock!")
 
 
-def wait_for_answer():
-    answer = input("Please type your answer (y/N): ")
-    while True:
-        if str.lower(answer.strip()) not in ['n', 'y', '']:
-            answer = input("Please type your answer again (y/N): ")
-        else:
-            break
-    print('Your answer is: %s' % 'N' if answer.strip() == '' else answer.strip())
-    if str.lower(answer.strip()) in ['n', '']:
-        sys.exit(1)
+    def wait_for_answer(self):
+        answer = input("Please type your answer (y/N): ")
+        while True:
+            if str.lower(answer.strip()) not in ['n', 'y', '']:
+                answer = input("Please type your answer again (y/N): ")
+            else:
+                break
+        
+        if self.args.verbose:
+            print('Your answer is: %s' % ('N' if answer.strip() == '' else answer.strip()))
+            
+        if str.lower(answer.strip()) in ['n', '']:
+            sys.exit(1)
 
 
-def handle_arguments(args: Namespace):
-    session_name_for_saving: str = args.save
-    session_name_for_restoring: str = args.restore
-    list_sessions = args.list
-    session_details = args.detail
-    close_all: list = args.close_all
-    pop_up_a_dialog_to_restore = args.pr
-    restoring_interval: int = args.restoring_interval
-    exclude: list = args.exclude
-    include: list = args.include
-    move_automatically = args.move_automatically
-    including_apps_with_multiple_windows = args.including_apps_with_multiple_windows
+    def handle_arguments(self):
+        session_name_for_saving: str = self.args.save
+        session_name_for_restoring: str = self.args.restore
+        list_sessions = self.args.list
+        session_details = self.args.detail
+        close_all: list = self.args.close_all
+        pop_up_a_dialog_to_restore = self.args.pr
+        restoring_interval: int = self.args.restoring_interval
+        exclude: list = self.args.exclude
+        include: list = self.args.include
+        move_automatically = self.args.move_automatically
+        including_apps_with_multiple_windows = self.args.including_apps_with_multiple_windows
 
-    if session_name_for_saving:
-        print(constants.Prompts.MSG_SAVE % session_name_for_saving)
-        wait_for_answer()
-        xsm = XSessionManager()
-        xsm.save_session(session_name_for_saving)
-
-    if close_all is not None:
-        print(constants.Prompts.MSG_CLOSE_ALL_WINDOWS)
-        wait_for_answer()
-        # TODO Order sensitive?
-        xsm = XSessionManager([IncludeSessionFilter(close_all),
-                               IncludeSessionFilter(include),
-                               ExcludeSessionFilter(exclude)])
-        xsm.close_windows(including_apps_with_multiple_windows)
-        print('Done!')
-
-    if session_name_for_restoring:
-        print(constants.Prompts.MSG_RESTORE % session_name_for_restoring)
-        wait_for_answer()
-        xsm = XSessionManager([IncludeSessionFilter(include),
-                               ExcludeSessionFilter(exclude)])
-        xsm.restore_session(session_name_for_restoring, restoring_interval)
-
-    if pop_up_a_dialog_to_restore:
-        answer = create_askyesno_dialog(constants.Prompts.MSG_POP_UP_A_DIALOG_TO_RESTORE
-                                        % pop_up_a_dialog_to_restore)
-        if answer:
+        if session_name_for_saving:
+            print(constants.Prompts.MSG_SAVE % session_name_for_saving)
+            self.wait_for_answer()
             xsm = XSessionManager()
-            xsm.restore_session(pop_up_a_dialog_to_restore, restoring_interval)
+            xsm.save_session(session_name_for_saving)
 
-    if list_sessions:
-        print()
-        import os
-        walk = os.walk(constants.Locations.BASE_LOCATION_OF_SESSIONS)
-        num = 0
-        for root, dirs, files in walk:
-            for file in files:
-                try:
-                    file_path = Path(root, file)
-                    with open(file_path, 'r') as f:
-                        num = num + 1
-                        namespace_objs: XSessionConfig = json.load(f, object_hook=lambda d: Namespace(**d))
-                        print(str(num) +'. ' + namespace_objs.session_name, namespace_objs.session_create_time, str(Path(root, file)),
-                            sep='  ')
-                except:
-                    print('Failed to list file: %s' % file_path)
-                    import traceback
-                    print(traceback.format_exc())
-                
-            break
+        if close_all is not None:
+            print(constants.Prompts.MSG_CLOSE_ALL_WINDOWS)
+            self.wait_for_answer()
+            # TODO Order sensitive?
+            xsm = XSessionManager([IncludeSessionFilter(close_all),
+                                IncludeSessionFilter(include),
+                                ExcludeSessionFilter(exclude)])
+            xsm.close_windows(including_apps_with_multiple_windows)
+            print('Done!')
 
-    if session_details:
-        session_path = Path(constants.Locations.BASE_LOCATION_OF_SESSIONS, session_details)
-        print('Looking for session located [%s] ' % session_path)
-        if not session_path.exists():
-            print('[%s] not found.' % session_path)
-            return
+        if session_name_for_restoring:
+            print(constants.Prompts.MSG_RESTORE % session_name_for_restoring)
+            self.wait_for_answer()
+            xsm = XSessionManager([IncludeSessionFilter(include),
+                                ExcludeSessionFilter(exclude)])
+            xsm.restore_session(session_name_for_restoring, restoring_interval)
 
-        print()
-        count = 0
-        with open(session_path, 'r') as file:
-            namespace_objs: XSessionConfig = json.load(file, object_hook=lambda d: Namespace(**d))
-            print('Session Name: %s' % namespace_objs.session_name)
-            print('Created At: %s' % namespace_objs.session_create_time)
-            print('Location: %s' % str(session_path))
+        if pop_up_a_dialog_to_restore:
+            answer = create_askyesno_dialog(constants.Prompts.MSG_POP_UP_A_DIALOG_TO_RESTORE
+                                            % pop_up_a_dialog_to_restore)
+            if answer:
+                xsm = XSessionManager()
+                xsm.restore_session(pop_up_a_dialog_to_restore, restoring_interval)
 
-            x_session_config_objects: List[XSessionConfigObject] = namespace_objs.x_session_config_objects
-            # Print data according to declared order
-            ordered_variables = vars(XSessionConfigObject)['__annotations__']
-            for x_session_config_object in x_session_config_objects:
-                count = count + 1
-                print('%d.' % count)
+        if list_sessions:
+            print()
+            import os
+            walk = os.walk(constants.Locations.BASE_LOCATION_OF_SESSIONS)
+            num = 0
+            for root, dirs, files in walk:
+                for file in files:
+                    try:
+                        file_path = Path(root, file)
+                        with open(file_path, 'r') as f:
+                            num = num + 1
+                            namespace_objs: XSessionConfig = json.load(f, object_hook=lambda d: Namespace(**d))
+                            print(str(num) +'. ' + namespace_objs.session_name, namespace_objs.session_create_time, str(Path(root, file)),
+                                sep='  ')
+                    except:
+                        print('Failed to list file: %s' % file_path)
+                        import traceback
+                        print(traceback.format_exc())
+                    
+                break
 
-                # Get fields in declared order
-                x_session_config_object_annotations = vars(XSessionConfigObject)['__annotations__']
+        if session_details:
+            session_path = Path(constants.Locations.BASE_LOCATION_OF_SESSIONS, session_details)
+            print('Looking for session located [%s] ' % session_path)
+            if not session_path.exists():
+                print('[%s] not found.' % session_path)
+                return
 
-                vars_in_x_session_config_object = vars(x_session_config_object)
-                keys_in_x_session_config_object = vars_in_x_session_config_object.keys()
-                for ordered_key in ordered_variables.keys():
-                    if ordered_key in keys_in_x_session_config_object:
-                        value = vars_in_x_session_config_object[ordered_key]
-                        if type(value) is Namespace:
-                            # Print data according to declared order
-                            _ordered_variables = \
-                                vars(x_session_config_object_annotations[ordered_key])['__annotations__']
-                            values = vars(value)
-                            values_to_be_printed = []
-                            for _ordered_key in _ordered_variables.keys():
-                                if _ordered_key in values.keys():
-                                    values_to_be_printed.append(_ordered_key.replace('_', ' ') + ": " +
-                                                                str(values[_ordered_key]))
-                            print('%s: %s' % (ordered_key.replace('_', ' '),
-                                              ''.join('\n    ' + str(v) for v in values_to_be_printed)))
-                        elif type(value) is list:
-                            # Such as 'notepad-plus-plus.exe' via Snap has many empty strings in its cmdline
-                            empty_slots_removed_str = ' '.join(ele for ele in value if ele != '')
-                            print('%s: %s' % (ordered_key.replace('_', ' '), empty_slots_removed_str))
-                        else:
-                            print('%s: %s' % (ordered_key.replace('_', ' '), value))
-                print()
+            print()
+            count = 0
+            with open(session_path, 'r') as file:
+                namespace_objs: XSessionConfig = json.load(file, object_hook=lambda d: Namespace(**d))
+                print('Session Name: %s' % namespace_objs.session_name)
+                print('Created At: %s' % namespace_objs.session_create_time)
+                print('Location: %s' % str(session_path))
 
-    if move_automatically:
-        xsm = XSessionManager([IncludeSessionFilter(include),
-                               ExcludeSessionFilter(exclude)])
-        xsm.move_window(move_automatically)
+                x_session_config_objects: List[XSessionConfigObject] = namespace_objs.x_session_config_objects
+                # Print data according to declared order
+                ordered_variables = vars(XSessionConfigObject)['__annotations__']
+                for x_session_config_object in x_session_config_objects:
+                    count = count + 1
+                    print('%d.' % count)
+
+                    # Get fields in declared order
+                    x_session_config_object_annotations = vars(XSessionConfigObject)['__annotations__']
+
+                    vars_in_x_session_config_object = vars(x_session_config_object)
+                    keys_in_x_session_config_object = vars_in_x_session_config_object.keys()
+                    for ordered_key in ordered_variables.keys():
+                        if ordered_key in keys_in_x_session_config_object:
+                            value = vars_in_x_session_config_object[ordered_key]
+                            if type(value) is Namespace:
+                                # Print data according to declared order
+                                _ordered_variables = \
+                                    vars(x_session_config_object_annotations[ordered_key])['__annotations__']
+                                values = vars(value)
+                                values_to_be_printed = []
+                                for _ordered_key in _ordered_variables.keys():
+                                    if _ordered_key in values.keys():
+                                        values_to_be_printed.append(_ordered_key.replace('_', ' ') + ": " +
+                                                                    str(values[_ordered_key]))
+                                print('%s: %s' % (ordered_key.replace('_', ' '),
+                                                ''.join('\n    ' + str(v) for v in values_to_be_printed)))
+                            elif type(value) is list:
+                                # Such as 'notepad-plus-plus.exe' via Snap has many empty strings in its cmdline
+                                empty_slots_removed_str = ' '.join(ele for ele in value if ele != '')
+                                print('%s: %s' % (ordered_key.replace('_', ' '), empty_slots_removed_str))
+                            else:
+                                print('%s: %s' % (ordered_key.replace('_', ' '), value))
+                    print()
+
+        if move_automatically:
+            xsm = XSessionManager([IncludeSessionFilter(include),
+                                ExcludeSessionFilter(exclude)])
+            xsm.move_window(move_automatically)

--- a/xsession_manager/arguments_handler.py
+++ b/xsession_manager/arguments_handler.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -152,27 +153,29 @@ class ArgumentsHandler():
                 xsm = XSessionManager()
                 xsm.restore_session(pop_up_a_dialog_to_restore, restoring_interval)
 
+        # Sort sessions based on motification time in ascending order
         if list_sessions:
             print()
-            import os
-            walk = os.walk(constants.Locations.BASE_LOCATION_OF_SESSIONS)
-            num = 0
-            for root, dirs, files in walk:
-                for file in files:
-                    try:
-                        file_path = Path(root, file)
-                        with open(file_path, 'r') as f:
-                            num = num + 1
-                            namespace_objs: XSessionConfig = json.load(f, object_hook=lambda d: Namespace(**d))
-                            print(str(num) +'. ' + namespace_objs.session_name, namespace_objs.session_create_time, str(Path(root, file)),
-                                sep='  ')
-                    except:
-                        print('Failed to list file: %s' % file_path)
-                        import traceback
-                        print(traceback.format_exc())
-                    
-                break
-
+            session_files = filter(lambda x: os.path.isfile(os.path.join(constants.Locations.BASE_LOCATION_OF_SESSIONS, x)), 
+                                   os.listdir(constants.Locations.BASE_LOCATION_OF_SESSIONS) )
+            session_files = sorted(session_files, 
+                                   key = lambda x: os.path.getmtime(os.path.join(constants.Locations.BASE_LOCATION_OF_SESSIONS, x)))
+            num = 0            
+            for file in session_files:
+                try:
+                    file_path = Path(constants.Locations.BASE_LOCATION_OF_SESSIONS, file)
+                    with open(file_path, 'r') as f:
+                        num = num + 1
+                        namespace_objs: XSessionConfig = json.load(f, object_hook=lambda d: Namespace(**d))
+                        print(str(num) +'. ' + namespace_objs.session_name, 
+                              namespace_objs.session_create_time, 
+                              str(Path(constants.Locations.BASE_LOCATION_OF_SESSIONS, file)),
+                              sep='  ')
+                except:
+                    print('Failed to list file: %s' % file_path)
+                    import traceback
+                    print(traceback.format_exc())
+                
         if session_details:
             session_path = Path(constants.Locations.BASE_LOCATION_OF_SESSIONS, session_details)
             if self.args.verbose:

--- a/xsession_manager/arguments_handler.py
+++ b/xsession_manager/arguments_handler.py
@@ -119,16 +119,18 @@ class ArgumentsHandler():
         if session_name_for_saving:
             print(constants.Prompts.MSG_SAVE % session_name_for_saving)
             self.wait_for_answer()
-            xsm = XSessionManager()
+            xsm = XSessionManager(verbose=self.args.verbose, vv=self.args.vv)
             xsm.save_session(session_name_for_saving)
 
         if close_all is not None:
             print(constants.Prompts.MSG_CLOSE_ALL_WINDOWS)
             self.wait_for_answer()
             # TODO Order sensitive?
-            xsm = XSessionManager([IncludeSessionFilter(close_all),
-                                IncludeSessionFilter(include),
-                                ExcludeSessionFilter(exclude)])
+            xsm = XSessionManager(verbose=self.args.verbose,
+                                  vv=self.args.vv,
+                                  session_filters=[IncludeSessionFilter(close_all),
+                                                   IncludeSessionFilter(include),
+                                                   ExcludeSessionFilter(exclude)])
             xsm.close_windows(including_apps_with_multiple_windows)
             print('Done!')
 
@@ -142,15 +144,17 @@ class ArgumentsHandler():
                         
             print(constants.Prompts.MSG_RESTORE % session_name_for_restoring)
             self.wait_for_answer()
-            xsm = XSessionManager([IncludeSessionFilter(include),
-                                ExcludeSessionFilter(exclude)])
+            xsm = XSessionManager(verbose=self.args.verbose,
+                                  vv=self.args.vv,
+                                  session_filters=[IncludeSessionFilter(include),
+                                                   ExcludeSessionFilter(exclude)])
             xsm.restore_session(session_name_for_restoring, restoring_interval)
 
         if pop_up_a_dialog_to_restore:
             answer = create_askyesno_dialog(constants.Prompts.MSG_POP_UP_A_DIALOG_TO_RESTORE
                                             % pop_up_a_dialog_to_restore)
             if answer:
-                xsm = XSessionManager()
+                xsm = XSessionManager(verbose=self.args.verbose, vv=self.args.vv)
                 xsm.restore_session(pop_up_a_dialog_to_restore, restoring_interval)
 
         # Sort sessions based on motification time in ascending order
@@ -228,6 +232,8 @@ class ArgumentsHandler():
                     print()
 
         if move_automatically:
-            xsm = XSessionManager([IncludeSessionFilter(include),
-                                ExcludeSessionFilter(exclude)])
+            xsm = XSessionManager(verbose=self.args.verbose,
+                                  vv=self.args.vv,
+                                  session_filters=[IncludeSessionFilter(include),
+                                                   ExcludeSessionFilter(exclude)])
             xsm.move_window(move_automatically)

--- a/xsession_manager/arguments_handler.py
+++ b/xsession_manager/arguments_handler.py
@@ -86,20 +86,6 @@ class ArgumentsHandler():
                 raise argparse.ArgumentTypeError('argument -ma/--move-automatically : '
                                                 'not allowed with any argument of -s/--save, -r/--restore, -c/--close-all')
 
-        if close_all is None \
-                and not string_utils.empty_string(restore):
-            # get the opening windows via wmctl
-            if vv:
-                print("Opening windows list:")
-                running_windows = wmctl_wrapper.get_running_windows_raw()
-                if len(running_windows) > 0:
-                    for rw in running_windows:
-                        print(rw)
-                    
-            print('Do you want to continue to restore a session?')
-            self.wait_for_answer()
-            print("Let's rock!")
-
 
     def wait_for_answer(self):
         answer = input("Please type your answer (y/N): ")
@@ -146,6 +132,13 @@ class ArgumentsHandler():
             print('Done!')
 
         if session_name_for_restoring:
+            if self.args.vv:
+                print("Opening windows list:")
+                running_windows = wmctl_wrapper.get_running_windows_raw()
+                if len(running_windows) > 0:
+                    for rw in running_windows:
+                        print(rw)
+                        
             print(constants.Prompts.MSG_RESTORE % session_name_for_restoring)
             self.wait_for_answer()
             xsm = XSessionManager([IncludeSessionFilter(include),
@@ -182,7 +175,8 @@ class ArgumentsHandler():
 
         if session_details:
             session_path = Path(constants.Locations.BASE_LOCATION_OF_SESSIONS, session_details)
-            print('Looking for session located [%s] ' % session_path)
+            if self.args.verbose:
+                print('Looking for session located [%s] ' % session_path)
             if not session_path.exists():
                 print('[%s] not found.' % session_path)
                 return

--- a/xsession_manager/arguments_handler.py
+++ b/xsession_manager/arguments_handler.py
@@ -27,7 +27,7 @@ def check_and_reset_args(args: Namespace):
 
     # Need to deal with this kind of case when user type -s' '
     argv = [a.strip() for a in sys.argv[1:]]
-    print('Arguments input by user: ' + str(argv))
+    # print('Arguments input by user: ' + str(argv))
     if string_utils.empty_string(save) \
             and ('-s' in argv or '--save' in argv):
         args.save = Locations.DEFAULT_SESSION_NAME
@@ -54,7 +54,7 @@ def check_and_reset_args(args: Namespace):
         raise argparse.ArgumentTypeError('argument -im/--including-apps-with-multiple-windows : '
                                          'only allowed with -c/--close-all')
 
-    print('Namespace object after handling by this program: ' + str(args))
+    # print('Namespace object after handling by this program: ' + str(args))
 
     if save or restore or close_all:
         if list_sessions:

--- a/xsession_manager/arguments_parser.py
+++ b/xsession_manager/arguments_parser.py
@@ -61,7 +61,14 @@ class ArgumentsParser:
         parser.add_argument('--version',
                             action='version',
                             version=__version__)
-
+        
+        parser.add_argument('-v', '--verbose',
+                            action='store_true',
+                            help='Print debugging information')
+        parser.add_argument('-vv',
+                            action='store_true',
+                            help='Print more debugging information, could contain sensitive info')
+        
         if len(sys.argv) == 1:
             print('No arguments provided.\n')
             parser.print_help(sys.stderr)

--- a/xsession_manager/main.py
+++ b/xsession_manager/main.py
@@ -10,7 +10,7 @@ def run():
     check_login_condition()
     parser = ArgumentsParser()
     args = parser.parse_arguments()
-    print('Namespace object before handling by this program: ' + str(args))
+    # print('Namespace object before handling by this program: ' + str(args))
     arguments_handler.check_and_reset_args(args)
     arguments_handler.handle_arguments(args)
 

--- a/xsession_manager/main.py
+++ b/xsession_manager/main.py
@@ -3,16 +3,16 @@ import os
 import sys
 
 from .arguments_parser import ArgumentsParser
-from . import arguments_handler
+from .arguments_handler import ArgumentsHandler
 
 
 def run():
     check_login_condition()
     parser = ArgumentsParser()
     args = parser.parse_arguments()
-    # print('Namespace object before handling by this program: ' + str(args))
-    arguments_handler.check_and_reset_args(args)
-    arguments_handler.handle_arguments(args)
+    arguments_handler = ArgumentsHandler(args)
+    arguments_handler.check_and_preset_args()
+    arguments_handler.handle_arguments()
 
 
 def check_login_condition():

--- a/xsession_manager/tests/snapd_workaround_test.py
+++ b/xsession_manager/tests/snapd_workaround_test.py
@@ -43,6 +43,6 @@ def test_get_desktop_file():
 
 
 def test_launch_app():
-    launched = snapd_workaround.Snapd().launch(['authy'], False, False)
+    launched = snapd_workaround.Snapd().launch_app(['authy'], False, False)
     assert launched is True
 

--- a/xsession_manager/utils/gio_utils.py
+++ b/xsession_manager/utils/gio_utils.py
@@ -1,4 +1,5 @@
 from typing import List, Dict
+import re
 
 import gi
 from gi.overrides.Gio import Settings

--- a/xsession_manager/utils/gio_utils.py
+++ b/xsession_manager/utils/gio_utils.py
@@ -85,7 +85,8 @@ class GDesktopAppInfo:
 
             so = suppress_output.SuppressOutput(True, True)
             with so.suppress_output():
-                return desktop_app_info.launch()
+                launched = desktop_app_info.launch()
+                return launched
         elif len(desktop_apps) == 0:
             print('No result found according to %s' % app_name)
             return False
@@ -106,7 +107,8 @@ class GDesktopAppInfo:
 
                 so = suppress_output.SuppressOutput(True, True)
                 with so.suppress_output():
-                    return desktop_app_info.launch()
+                    launched = desktop_app_info.launch()
+                    return launched
 
             raise MoreThanOneResultFound('Multiple desktop files (%s) were found according to %s'
                                          % ([desktop_app.app_id for desktop_app in desktop_apps], app_name))

--- a/xsession_manager/utils/snapd_workaround.py
+++ b/xsession_manager/utils/snapd_workaround.py
@@ -5,7 +5,7 @@
 
 import json
 import re
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import pycurl
 
@@ -60,7 +60,7 @@ class Snapd:
         return result[0]
 
     @staticmethod
-    def is_snap_app(app_cmd: str) -> (bool, str):
+    def is_snap_app(app_cmd: str) -> Tuple[bool, str]:
         # Visit https://regex101.com/r/SXUlVX/ to check the explanation of this regular expression pattern
         c = re.compile(r'([\/]|[\\]{,2})snap([\/]|[\\]{,2})[\w:\-]+([\/]|[\\]{,2})[\d]+')
         r = c.search(app_cmd)
@@ -70,7 +70,7 @@ class Snapd:
             return True, snap_app_name
         return False, None
 
-    def launch(self, app_names: List[str], suppress_stdout=True, suppress_stderr=True) -> bool:
+    def launch_app(self, app_names: List[str], suppress_stdout=True, suppress_stderr=True) -> bool:
         """
         Launch a application according to the app names.
 
@@ -86,6 +86,6 @@ class Snapd:
             df = app['desktop-file']
             so = suppress_output.SuppressOutput(suppress_stdout, suppress_stderr)
             with so.suppress_output():
-                return gio_utils.GDesktopAppInfo.launch_app_via_desktop_file(df)
+                return gio_utils.GDesktopAppInfo().launch_app_via_desktop_file(df)
 
         print('Failed to run apps %s as a Snap app' % app_names)

--- a/xsession_manager/utils/snapd_workaround.py
+++ b/xsession_manager/utils/snapd_workaround.py
@@ -70,7 +70,7 @@ class Snapd:
             return True, snap_app_name
         return False, None
 
-    def launch_app(self, app_names: List[str], suppress_stdout=True, suppress_stderr=True) -> bool:
+    def launch_app(self, app_names: List[str], launched_callback, suppress_stdout=True, suppress_stderr=True) -> bool:
         """
         Launch a application according to the app names.
 
@@ -86,6 +86,6 @@ class Snapd:
             df = app['desktop-file']
             so = suppress_output.SuppressOutput(suppress_stdout, suppress_stderr)
             with so.suppress_output():
-                return gio_utils.GDesktopAppInfo().launch_app_via_desktop_file(df)
+                return gio_utils.GDesktopAppInfo().launch_app_via_desktop_file(df, launched_callback)
 
         print('Failed to run apps %s as a Snap app' % app_names)

--- a/xsession_manager/utils/subprocess_utils.py
+++ b/xsession_manager/utils/subprocess_utils.py
@@ -8,3 +8,5 @@ def run_cmd(commandline: list):
     # subprocess.DEVNULL only support > 3.3
     return subprocess.Popen(commandline, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
+def launch_app(commandline: list):
+    return run_cmd(commandline)

--- a/xsession_manager/utils/wnck_utils.py
+++ b/xsession_manager/utils/wnck_utils.py
@@ -51,6 +51,9 @@ def get_workspace_count():
 
 def get_app_name(xid: int) -> str:
     window = get_window(xid)
+    if not window:
+        return ''
+    
     # See: https://developer.gnome.org/libwnck/stable/WnckWindow.html#wnck-window-get-class-group-name
     # See: https://tronche.com/gui/x/icccm/sec-4.html#WM_CLASS
     name = window.get_class_group_name()

--- a/xsession_manager/utils/wnck_utils.py
+++ b/xsession_manager/utils/wnck_utils.py
@@ -1,6 +1,7 @@
 # Note: Wnck may not works in Wayland
 from contextlib import contextmanager
 from time import time
+from typing import Tuple
 
 from . import gio_utils
 
@@ -117,7 +118,7 @@ def count_windows(xid: int) -> int:
     return app.get_n_windows()
 
 
-def get_geometry(xid: int) -> (int, int, int, int):
+def get_geometry(xid: int) -> Tuple[int, int, int, int]:
     window = get_window(xid)
     if window:
         geometry = window.get_geometry()

--- a/xsession_manager/utils/wnck_utils.py
+++ b/xsession_manager/utils/wnck_utils.py
@@ -73,6 +73,9 @@ def get_window(xid: int) -> Wnck.Window:
         Gtk.main_iteration()
     screen.force_update()
     window: Wnck.Window = Wnck.Window.get(xid)
+    if not window:
+        print('window not found: %s(%s)' % (xid, hex(xid)))
+        return None
     return window
 
 
@@ -106,6 +109,8 @@ def is_above(xid: int) -> bool:
 
 def make_above(xid: int):
     window: Wnck.Window = get_window(xid)
+    if not window:
+        return
     window.make_above()
 
 

--- a/xsession_manager/xsession_manager.py
+++ b/xsession_manager/xsession_manager.py
@@ -245,9 +245,7 @@ class XSessionManager:
                 print('Restoring application:              [%s]' % app_name)
                 app_info = gio_utils.GDesktopAppInfo()
                 if len(cmd) == 0:
-                    so = suppress_output.SuppressOutput(not self.vv, not self.vv)
-                    with so.suppress_output():
-                        launched = app_info.launch_app(app_name)
+                    launched = app_info.launch_app(app_name)
                     if not launched:
                         print('Failure to restore the application named %s '
                               'due to empty commandline [%s]'

--- a/xsession_manager/xsession_manager.py
+++ b/xsession_manager/xsession_manager.py
@@ -214,7 +214,7 @@ class XSessionManager:
 
         failed_restores = []
         succeeded_restores = []
-        running_session: XSessionConfigObject = self.get_session_details(remove_duplicates_by_pid=False, 
+        running_session: XSessionConfig = self.get_session_details(remove_duplicates_by_pid=False, 
                                                                          session_filters=self.session_filters);
         for index, namespace_obj in enumerate(_x_session_config_objects_copy):
             cmd: list = namespace_obj.cmd
@@ -223,7 +223,7 @@ class XSessionManager:
                 is_running = False
                 for running_window in running_session.x_session_config_objects:
                     if self._is_same_window(running_window, namespace_obj) and self._is_same_cmd(running_window.cmd, cmd):
-                        print('%s is running, skip...' % app_name)
+                        print('%s is running in Workspace %d, skip...' % (app_name, running_window.desktop_number))
                         is_running = True
                         break;
                 if is_running:

--- a/xsession_manager/xsession_manager.py
+++ b/xsession_manager/xsession_manager.py
@@ -228,7 +228,7 @@ class XSessionManager:
             try:
                 is_running = False
                 for running_window in running_session.x_session_config_objects:
-                    if self._is_same_window(running_window, namespace_obj) \
+                    if self._is_same_app(running_window, namespace_obj) \
                             and self._is_same_cmd(running_window.cmd, cmd):
                         print('%s is running in Workspace %d, skip...' % (app_name, running_window.desktop_number))
                         is_running = True
@@ -498,6 +498,14 @@ class XSessionManager:
             if window_state.is_above:
                 wnck_utils.make_above(window_id_the_int_type)
 
+    def _is_same_app(self, running_window1: XSessionConfigObject, window2: XSessionConfigObject):
+        app_name1 = wnck_utils.get_app_name(running_window1.window_id_the_int_type)
+        app_name2 = window2.app_name
+        if string_utils.empty_string(app_name1) \
+                or string_utils.empty_string(app_name2):
+            return False
+        return app_name1 == app_name2
+    
     def _is_same_window(self, running_window1: XSessionConfigObject, window2: XSessionConfigObject):
         # Deal with JetBrains products. Move the window if they are the same project.
         app_name1 = wnck_utils.get_app_name(running_window1.window_id_the_int_type)


### PR DESCRIPTION
1. Add `-v / --verbose` and `-vv` so that all debugging information will be omitted by default
2. Use `Wnck.AppLaunchContext` to get the pid after a app launched
3. Move `DesktopAppInfo` cache to `__init__` function
4. Match the whole word while search `.desktop` by an app name
5. Only ask once before restore apps
6. Improve `xsm -l`: 1) Add the serial number in the results 2) Sort the results by file modification time in ascending order
7. Skip running apps while restore and exit immediately if all apps have been running already
8. Fix cannot restore flathub app spotify and snap app superproductivity via `xsm -r -i super` and `xsm -r -i spotify` respectively
9. Other improvements